### PR TITLE
Fixed after SC v3 Upgrade

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,8 +3,8 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
-use Statamic\Statamic;
 use Statamic\Facades\CP\Nav;
+use Statamic\Statamic;
 
 // use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 // use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
@@ -12,45 +12,44 @@ use Statamic\Facades\CP\Nav;
 
 class AppServiceProvider extends ServiceProvider
 {
-	/**
-	 * Register any application services.
-	 *
-	 * @return void
-	 */
-	public function register()
-	{
-		//
-	}
+    /**
+     * Register any application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        //
+    }
 
-	/**
-	 * Bootstrap any application services.
-	 *
-	 * @return void
-	 */
-	public function boot()
-	{
-		// Statamic::script('app', 'cp');
-		// Statamic::style('app', 'cp');
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        // Statamic::script('app', 'cp');
+        // Statamic::style('app', 'cp');
 
-		// Nav::extend(function ($nav) {
-		// 	$nav->content('Collections')    ->name('Entries');
-		// 	$nav->content('Navigation')     ->name('Menus');
-		// 	$nav->content('Taxonomies')     ->name('Categories');
-		// 	$nav->content('Assets')         ->name('Uploads');
-		// 	$nav->content('Globals')        ->name('Settings');
-		// });
+        Nav::extend(function ($nav) {
+            $nav->content('Collections')->name('Entries');
+            $nav->content('Navigation')->name('Menus');
+            $nav->content('Taxonomies')->name('Categories');
+            $nav->content('Assets')->name('Uploads');
+            $nav->content('Globals')->name('Settings');
+        });
 
-		 
-		// SimpleCommerce::productPriceHook(function (Order $order, Product $product) {
-		// 	if ( !empty($product->data['open_price']) ) {
-		// 		foreach ( $order->data['items'] as $item) {
-		// 			if ($item['product'] == $product->id) {
-		// 				return $item['metadata']['amount'] * 100;
-		// 			}
-		// 		}
-		// 	} else {
-		// 		return $product->get('price');
-		// 	}
-		// });        
-	}
+        // SimpleCommerce::productPriceHook(function (Order $order, Product $product) {
+        // 	if ( !empty($product->data['open_price']) ) {
+        // 		foreach ( $order->data['items'] as $item) {
+        // 			if ($item['product'] == $product->id) {
+        // 				return $item['metadata']['amount'] * 100;
+        // 			}
+        // 		}
+        // 	} else {
+        // 		return $product->get('price');
+        // 	}
+        // });
+    }
 }

--- a/config/simple-commerce.php
+++ b/config/simple-commerce.php
@@ -134,25 +134,26 @@ return [
 	|
 	*/
 
-	'content' => [
-		'orders' => [
-			'driver' => \DoubleThreeDigital\SimpleCommerce\Orders\Order::class,
-			'collection' => 'orders',
-		],
-		'products' => [
-			'driver' => \DoubleThreeDigital\SimpleCommerce\Products\Product::class,
-			'collection' => 'products',
-		],
-		'coupons' => [
-			'driver' => \DoubleThreeDigital\SimpleCommerce\Coupons\Coupon::class,
-			'collection' => 'coupons',
-		],
-		'customers' => [
-			// 'driver' => \DoubleThreeDigital\SimpleCommerce\Customers\Customer::class,
-			'driver' => \DoubleThreeDigital\SimpleCommerce\Customers\UserCustomer::class,
-			// 'collection' => 'customers',
-		],
-	],
+    'content' => [
+        'coupons' => [
+            'repository' => \DoubleThreeDigital\SimpleCommerce\Coupons\EntryCouponRepository::class,
+            'collection' => 'coupons',
+        ],
+
+        'customers' => [
+            'repository' => \DoubleThreeDigital\SimpleCommerce\Customers\UserCustomerRepository::class,
+        ],
+
+        'orders' => [
+            'repository' => \DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository::class,
+            'collection' => 'orders',
+        ],
+
+        'products' => [
+            'repository' => \DoubleThreeDigital\SimpleCommerce\Products\EntryProductRepository::class,
+            'collection' => 'products',
+        ],
+    ],
 
 	/*
 	|--------------------------------------------------------------------------

--- a/config/simple-commerce.php
+++ b/config/simple-commerce.php
@@ -195,4 +195,6 @@ return [
 
 	'low_stock_threshold' => 25,
 
+    'disable_form_parameter_validation' => true,
+
 ];


### PR DESCRIPTION
Changes:

* I've uncommented the CP Nav code in your `AppServiceProvider` - you'll need to update to [v3.2.15](https://github.com/doublethreedigital/simple-commerce/releases/tag/v3.2.15) for it to be fixed
* Updated the `content` array in the Simple Commerce config - it should have been automated during upgrade but it obviously failed (will fix your export error)
* Disabled 'form parameter validation' - basically in v3, all of the hidden parameters, like `_redirect` are encrypted by the tag, then decrypted on form submission. However, since you're setting the [`_redirect` value manually](https://github.com/remiduval/apc/blob/main/resources/views/sets/selection.antlers.html#L98), you won't want the encryption/decryption stuff to be done. ([docs](https://simple-commerce.duncanmcclean.com/tags#content-form-tags))