### PR TITLE
Add 'title format' to orders collection

### DIFF
--- a/content/collections/orders.yaml
+++ b/content/collections/orders.yaml
@@ -2,5 +2,9 @@ title: Orders
 sites:
   - english
   - french
+propagate: false
+template: default
+layout: layout
 revisions: false
+title_format: '#{order_number}'
 sort_dir: desc


### PR DESCRIPTION
During the upgrade process, a title format should have been added to the order collection (but it wasn't due to the error you experienced)